### PR TITLE
Properly check for group, series and property override value

### DIFF
--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -456,12 +456,12 @@ function _pmp_select_for_post($post, $type) {
 		'limit' => 9999
 	));
 
-	$override = get_post_meta($post->ID, $meta_key = 'pmp_' . $type . '_override', true);
+	$override = pmp_get_collection_override_value($post, $type);
 	$options = array();
 
 	// Pad the options with an empty value
 	$options[] = array(
-		'selected' => '',
+		'selected' => selected($override, false, false),
 		'guid' => '',
 		'title' => '--- No ' . $type . ' ---'
 	);
@@ -469,11 +469,9 @@ function _pmp_select_for_post($post, $type) {
 	foreach ($pmp_things['items'] as $thing) {
 		if (!empty($override))
 			$selected = selected($override, $thing['attributes']['guid'], false);
-		else
-			$selected = selected($ret['default_guid'], $thing['attributes']['guid'], false);
 
 		$option = array(
-			'selected' => $selected,
+			'selected' => (isset($selected))? $selected : '',
 			'guid' => $thing['attributes']['guid'],
 			'title' => $thing['attributes']['title']
 		);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -251,20 +251,18 @@ function pmp_handle_push($post_id) {
 	if ($post->post_type == 'post') {
 		$obj->links->collection = array();
 
-		$series_override = get_post_meta($post_id, 'pmp_series_override', true);
-		$series = (empty($series_override))? get_option('pmp_default_series', false) : $series_override;
+		$series = pmp_get_collection_override_value($post_id, 'series');
 		if (!empty($series))
 			$obj->links->collection[] = (object) array('href' => $sdk->href4guid($series));
 
-		$property_override = get_post_meta($post_id, 'pmp_property_override', true);
-		$property = (empty($property_override))? get_option('pmp_default_property', false) : $property_override;
+		$property = pmp_get_collection_override_value($post_id, 'property');
 		if (!empty($property))
 			$obj->links->collection[] = (object) array('href' => $sdk->href4guid($property));
 	}
 
 	// Build out the permissions group profile array
-	$group_override = get_post_meta($post_id, 'pmp_group_override', true);
-	$group = (empty($group_override))? get_option('pmp_default_group', false) : $group_override;
+	$obj->links->permission = array();
+	$group = pmp_get_collection_override_value($post_id, 'group');
 	if (!empty($group))
 		$obj->links->permission[] = (object) array('href' => $sdk->href4guid($group));
 
@@ -550,6 +548,29 @@ function pmp_delete_saved_query_by_id($search_id) {
 
 	unset($search_queries[$search_id]);
 	return update_option('pmp_saved_search_queries', $search_queries);
+}
+
+/**
+ * Get the override value for property, series, group for a post
+ *
+ * @param $post (integer|object) the post id or post object to check for override values.
+ * @param $type (string) the collection type override to check for (e.g., property, series or group)
+ * @since 0.3
+ */
+function pmp_get_collection_override_value($post, $type) {
+	$post = get_post($post);
+	$pmp_guid = get_post_meta($post->ID, 'pmp_guid', true);
+	$override = get_post_meta($post->ID, 'pmp_' . $type . '_override', true);
+
+	if (empty($override)) {
+		if (empty($pmp_guid))
+			$value = get_option('pmp_default_' . $type, false);
+		else
+			$value = false;
+	} else
+		$value = $override;
+
+	return $value;
 }
 
 if (!function_exists('var_log')) {

--- a/inc/meta-boxes.php
+++ b/inc/meta-boxes.php
@@ -98,12 +98,9 @@ function pmp_save_override_defaults($post_id) {
 		if (isset($_POST[$meta_key])) {
 			$override_guid = $_POST[$meta_key];
 
-			// If we're setting the override to the default, or the override is set to
-			// nothing, just delete the override meta and continue
-			if ($override_guid == $default_guid || empty($override_guid)) {
-				delete_post_meta($post_id, $meta_key);
-				continue;
-			}
+			// Indicate that the $type was explicitly net to false
+			if (empty($override_guid))
+				$override_guid = false;
 
 			// Otherwise, set the override meta
 			update_post_meta($post_id, $meta_key, $override_guid);

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -275,6 +275,10 @@ class TestFunctions extends WP_UnitTestCase {
 		$this->assertTrue(empty($result));
 	}
 
+	function test_pmp_get_collection_override_value() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
 	function test_var_log() {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}


### PR DESCRIPTION
Addresses #48 (reopened).

Uses newly added function `pmp_get_collection_override_value` to check for the override value for group, series, property based on the context for a post.

- Use default values for group, series and property if they are set when initially pushing to PMP.
- If the value for group, series or property is explicitly set to none, honor that value even on initial push to PMP.
- Allow changing the group, series, property after initial push.

