### PR TITLE
Deal with "Uncategorized" when importing posts via saved search

### DIFF
--- a/inc/cron.php
+++ b/inc/cron.php
@@ -160,7 +160,7 @@ function pmp_import_for_saved_queries() {
 				// Make sure "Uncategorized" category doesn't stick around if it
 				// wasn't explicitly set as a category for the saved search import.
 				$assigned_categories = wp_get_post_categories($post_id);
-				$uncategorized = get_category_by_slug('uncategorized');
+				$uncategorized = get_category_by_slug(1);
 
 				// Check for "Uncategorized" in the already-assigned categories
 				$in_assigned_cats = array_search($uncategorized->term_id, $assigned_categories);

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -156,8 +156,27 @@ function pmp_import_for_saved_queries() {
 			} else
 				$post_id = $query->posts[0]->ID;
 
-			if (isset($query_data->options->post_category))
-				wp_set_post_categories($post_id, $query_data->options->post_category, true);
+			if (isset($query_data->options->post_category)) {
+				// Make sure "Uncategorized" category doesn't stick around if it
+				// wasn't explicitly set as a category for the saved search import.
+				$assigned_categories = wp_get_post_categories($post_id);
+				$uncategorized = get_category_by_slug('uncategorized');
+
+				// Check for "Uncategorized" in the already-assigned categories
+				$in_assigned_cats = array_search($uncategorized->term_id, $assigned_categories);
+				// Check for "Uncategorized" in the saved-search categories
+				$in_saved_search_cats = array_search($uncategorized->term_id, $query_data->options->post_category);
+
+				// If "Uncategorized" is in assigned categories and NOT in saved-search categories, ditch it.
+				if ($in_assigned_cats >= 0 && $in_saved_search_cats === false)
+					unset($assigned_categories[array_search($uncategorized->term_id, $assigned_categories)]);
+
+				// Set the newly generated list of categories for the post
+				wp_set_post_categories(
+					$post_id, array_values(array_unique(array_merge(
+						$assigned_categories, $query_data->options->post_category)))
+				);
+			}
 		}
 
 		update_option('pmp_last_saved_search_cron_' . sanitize_title($query_data->options->title), date('c', time()));


### PR DESCRIPTION
See #84.

This is a weird quirk in core WordPress.

If you create a new post through the post editor and assign no category, the post will be saved with "Uncategorized." If, after saving the post, you attempt to remove "Uncategorized" and re-save, WordPress makes sure "Uncategorized" persists (i.e., posts MUST have at least one category set for some reason).

If you check another category and remove "Uncategorized" then re-save, WordPress will respect the removal of "Uncategorized."

So, it appears the problem for posts imported via saved search is that "Uncategorized" is left intact even if a custom set of categories are chosen from the saved search configuration dialog. What this pull request does is ensure that "Uncategorized" is not assigned if a custom set of categories has been specified.

Worth noting -- this patch does nothing to prevent users from setting "Uncategorized" as a custom category for saved searches. I think this is in line with the way WordPress behaves when editing posts. So, it will honor your request to import posts as uncategorized if you choose.