### PR TITLE
Fix PHP warnings, errors caused by undefined functions when cron runs via HTTP request

### DIFF
--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -466,18 +466,20 @@ function _pmp_select_for_post($post, $type) {
 		'title' => '--- No ' . $type . ' ---'
 	);
 
-	foreach ($pmp_things['items'] as $thing) {
-		if (!empty($override))
-			$selected = selected($override, $thing['attributes']['guid'], false);
-		else
-			$selected = selected($ret['default_guid'], $thing['attributes']['guid'], false);
+	if (!empty($pmp_things['items'])) {
+		foreach ($pmp_things['items'] as $thing) {
+			if (!empty($override))
+				$selected = selected($override, $thing['attributes']['guid'], false);
+			else
+				$selected = selected($ret['default_guid'], $thing['attributes']['guid'], false);
 
-		$option = array(
-			'selected' => $selected,
-			'guid' => $thing['attributes']['guid'],
-			'title' => $thing['attributes']['title']
-		);
-		$options[] = $option;
+			$option = array(
+				'selected' => $selected,
+				'guid' => $thing['attributes']['guid'],
+				'title' => $thing['attributes']['title']
+			);
+			$options[] = $option;
+		}
 	}
 
 	$ret['options'] = $options;

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -160,7 +160,7 @@ function pmp_import_for_saved_queries() {
 				// Make sure "Uncategorized" category doesn't stick around if it
 				// wasn't explicitly set as a category for the saved search import.
 				$assigned_categories = wp_get_post_categories($post_id);
-				$uncategorized = get_category_by_slug(1);
+				$uncategorized = get_category(1);
 
 				// Check for "Uncategorized" in the already-assigned categories
 				$in_assigned_cats = array_search($uncategorized->term_id, $assigned_categories);

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -57,6 +57,9 @@ function pmp_get_profiles() {
  */
 function pmp_media_sideload_image($file, $post_id, $desc=null) {
 	if (!empty($file)) {
+		include_once ABSPATH . 'wp-admin/includes/file.php';
+		include_once ABSPATH . 'wp-admin/includes/media.php';
+
 		// Set variables for storage, fix file filename for query strings.
 		preg_match('/[^\?]+\.(jpe?g|jpe|gif|png)\b/i', $file, $matches);
 		$file_array = array();


### PR DESCRIPTION
While I was unable to reproduce the issue described in #88, I managed to fix a few glaring issue that may or may not have been contributing to the problem.

What this patch does:

- Functions `download_url` and `media_handle_sideload` are not normally available outside the context of the WordPress dashboard, so we need to explicitly include these functions so that our cron task will function properly when triggered by a front-end HTTP request.
- Check to make sure `$pmp_things['items']` is not empty before attempting to build an select menu data structure in `ajax.php`. This avoids an `Invalid argument` warning from PHP.