### PR TITLE
A bunch of enhancements to the search page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -151,6 +151,11 @@ p.submit input {
   margin: 6px 0;
 }
 
+.pmp-search-result .pmp-date-line {
+  font-size: 12px;
+  margin: 6px 0;
+}
+
 .pmp-search-result .pmp-teaser {
   font-size: 14px;
   margin: 6px 0;
@@ -190,6 +195,10 @@ p.submit input {
 
 .pmp-result-actions ul li:last-child:after {
   content: "";
+}
+.pmp-support-link .dashicons {
+  font-size: 14px;
+  text-decoration: none;
 }
 
 @media (max-width: 665px) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,6 +4,10 @@
   color: #777;
   margin: 4px 0;
 }
+.pmp-total-results {
+  position: relative;
+  top: 6px;
+}
 
 /* Basic text search */
 #pmp-search-page #pmp-search-form {

--- a/assets/js/pmp-common.js
+++ b/assets/js/pmp-common.js
@@ -219,11 +219,11 @@ var PMP = PMP || {};
     // Views
     PMP.BaseView = Backbone.View.extend({
         showSpinner: function() {
-            this.$el.find('.spinner').css('display', 'inline-block');
+            this.$el.find('.spinner').css({display: 'inline-block', visibility: 'visible'});
         },
 
         hideSpinner: function() {
-            this.$el.find('.spinner').css('display', 'none');
+            this.$el.find('.spinner').css({display: 'none', visibility: 'hidden'});
         }
     });
 

--- a/assets/js/pmp-search.js
+++ b/assets/js/pmp-search.js
@@ -26,9 +26,15 @@ var PMP = PMP || {};
             this.results = new ResultsList({ collection: this.docs });
             this.docs.on('reset', this.onReset.bind(this));
             this.docs.on('error', this.onError.bind(this));
+            this.docs.attributes.on('change', this.updateTotal.bind(this));
 
             if (options && typeof options.search !== 'undefined')
                 this.initSavedSearch(options);
+        },
+
+        updateTotal: function() {
+            this.$el.find('.pmp-total-results').html(
+                'Total results: ' + this.docs.attributes.get('total'));
         },
 
         initSavedSearch: function(options) {

--- a/assets/js/pmp-search.js
+++ b/assets/js/pmp-search.js
@@ -159,7 +159,8 @@ var PMP = PMP || {};
 
                 var tmpl_vars = _.extend(model.toJSON().attributes, {
                         image: image,
-                        creator: model.getCreatorAlias()
+                        creator: model.getCreatorAlias(),
+                        date: new Date(model.get('attributes').published)
                     }),
                     res = $(template(tmpl_vars));
 

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -134,27 +134,44 @@ function pmp_last_modified_meta($post) {
 	$pmp_mod = get_post_meta($post->ID, 'pmp_modified', true);
 	if (empty($pmp_guid)) return;
 
-	// Link to the PMP support searcher (for now)
-	$options = get_option('pmp_settings');
-	if ($options && $options['pmp_api_url'] && strpos($options['pmp_api_url'], 'sandbox')) {
-		$pmp_link = 'https://support.pmp.io/sandboxsearch?text=guid%3A' . $pmp_guid;
-	}
-	else {
-		$pmp_link = 'https://support.pmp.io/search?text=guid%3A' . $pmp_guid;
-	}
-
 	// Format similar to WP's published date
 	$pmp_local = get_date_from_gmt(date('Y-m-d H:i:s', strtotime($pmp_mod)), 'M n, Y @ G:i');
 ?>
   <div id="pmp-publish-meta">
 		<div class="misc-pub-section curtime">
-			<span id="timestamp">PMP guid: <b><a target="_blank" href="<?php echo $pmp_link; ?>"><?php echo substr($pmp_guid, 0, 8); ?><span class="ext-link dashicons dashicons-external"></span></a></b></span>
+			<span id="timestamp">PMP guid: <b><a target="_blank"
+				href="<?php echo pmp_get_support_link($pmp_guid); ?>"><?php echo substr($pmp_guid, 0, 8); ?><span class="ext-link dashicons dashicons-external"></span></a></b></span>
 		</div>
 		<div class="misc-pub-section curtime">
 			<span id="timestamp">PMP modified: <b><?php echo $pmp_local; ?></b></span>
 		</div>
 	</div>
 <?php
+}
+
+/**
+ * Get the base url for linking to the PMP support site
+ *
+ * @since 0.3
+ */
+function pmp_get_support_link_base() {
+	$options = get_option('pmp_settings');
+	if ($options && $options['pmp_api_url'] && strpos($options['pmp_api_url'], 'sandbox')) {
+		$pmp_link = 'https://support.pmp.io/sandboxsearch?text=guid%3A';
+	}
+	else {
+		$pmp_link = 'https://support.pmp.io/search?text=guid%3A';
+	}
+	return $pmp_link;
+}
+
+/**
+ * Get the support site url for a guid
+ *
+ * @since 0.3
+ */
+function pmp_get_support_link($guid) {
+	return pmp_get_support_link_base() . $guid;
 }
 
 /**

--- a/inc/pages.php
+++ b/inc/pages.php
@@ -28,9 +28,14 @@ function pmp_search_page() {
 
 	if (isset($_GET['search_id'])) {
 		$query_data = pmp_get_saved_search_query($_GET['search_id']);
-		$context['PMP'] = pmp_json_obj(array('search' => $query_data));
+		$context['PMP'] = pmp_json_obj(array(
+			'search' => $query_data,
+			'support_link_base' => pmp_get_support_link_base()
+		));
 	} else
-		$context['PMP'] = pmp_json_obj();
+		$context['PMP'] = pmp_json_obj(array(
+			'support_link_base' => pmp_get_support_link_base()
+		));
 
 	pmp_render_template('search.php', $context);
 }

--- a/templates/search.php
+++ b/templates/search.php
@@ -82,7 +82,7 @@
 			<div class="pmp-byline">
 				<% if (typeof byline != 'undefined' && byline != '') { %>By <%= byline %> | <% } %>
 				<span class="pmp-creator"><%= creator %></span> |
-				<span><a class="pmp-support-link" title="View this document on the PMP support site" href="<%= PMP.support_link_base %><%= guid %>"><%= guid.substr(0, 8) %><span class="ext-link dashicons dashicons-external"></span></a></span>
+				<span><a class="pmp-support-link" target="_blank" title="View this document on the PMP support site" href="<%= PMP.support_link_base %><%= guid %>"><%= guid.substr(0, 8) %><span class="ext-link dashicons dashicons-external"></span></a></span>
 			</div>
 			<% if (typeof teaser != 'undefined') { %>
 				<div class="pmp-teaser">

--- a/templates/search.php
+++ b/templates/search.php
@@ -60,6 +60,7 @@
 				<input type="button" name="save_query" id="pmp-save-query" class="button button-large"
 					value="<?php if (isset($PMP['search'])) { ?>Edit<?php } else { ?>Save<?php } ?> query" disabled="disabled"></input>
 				<span class="spinner"></span>
+				<span class="pmp-total-results"></span>
 			</p>
 		</form>
 

--- a/templates/search.php
+++ b/templates/search.php
@@ -76,9 +76,13 @@
 	<div class="pmp-search-result">
 		<h3 class="pmp-title"><%= title %></h3>
 		<div class="pmp-result-details">
+			<div class="pmp-date-line">
+				<span class="pmp-date">Published <%= date.toLocaleDateString() %> at <%= date.toLocaleTimeString() %></span>
+			</div>
 			<div class="pmp-byline">
 				<% if (typeof byline != 'undefined' && byline != '') { %>By <%= byline %> | <% } %>
-				<span class="pmp-creator"><%= creator %></span>
+				<span class="pmp-creator"><%= creator %></span> |
+				<span><a class="pmp-support-link" title="View this document on the PMP support site" href="<%= PMP.support_link_base %><%= guid %>"><%= guid.substr(0, 8) %><span class="ext-link dashicons dashicons-external"></span></a></span>
 			</div>
 			<% if (typeof teaser != 'undefined') { %>
 				<div class="pmp-teaser">

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -121,6 +121,14 @@ class TestFunctions extends WP_UnitTestCase {
 		$this->markTestIncomplete('This test has not been implemented yet.');
 	}
 
+	function test_pmp_get_support_link_base() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_get_support_link() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
 	function test_pmp_publish_actions_helper_draft() {
 		$post = get_post($this->post);
 		$post->post_status = 'draft';


### PR DESCRIPTION
To address #22.

Show the total number of results returned for a query:

![image](https://cloud.githubusercontent.com/assets/72608/8756373/66dd4e7c-2c97-11e5-9cb5-4d07a301a796.png)

Show the PMP partial guid and link to support site; show the published date:

![image](https://cloud.githubusercontent.com/assets/72608/8756388/7857c06a-2c97-11e5-82bb-458bf30ab786.png)


