### PR TITLE
Ability to use PMP's PubSubHubbub notifications rig instead of cron

### DIFF
--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -180,7 +180,6 @@ function pmp_do_notification_callback() {
 	global $wpdb;
 
 	$sdk = new SDKWrapper();
-	$headers = getallheaders();
 	$body = file_get_contents('php://input');
 	$hash = hash_hmac('sha1', $body, PMP_NOTIFICATIONS_SECRET);
 
@@ -189,7 +188,7 @@ function pmp_do_notification_callback() {
 		from $wpdb->postmeta where meta_key = 'pmp_guid'");
 	$pmp_guids = array_map(function($x) { return $x->pmp_guid; }, $pmp_post_data);
 
-	if ($headers['X-Hub-Signature'] == "sha1=$hash") {
+	if ($_SERVER['HTTP_X_HUB_SIGNATURE'] == "sha1=$hash") {
 		$xml = simplexml_load_string($body);
 
 		foreach ($xml->channel->item as $item) {

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -102,10 +102,10 @@ function pmp_subscription_verification($data) {
 
 	$settings = get_option('pmp_settings');
 
-	if (isset($settings['pmp_use_api_notifications']) && $settings['pmp_use_api_notifications'] == 'off')
-		$mode = 'subscribe';
-	else
+	if (isset($settings['pmp_use_api_notifications']) && $settings['pmp_use_api_notifications'] == 'on')
 		$mode = 'unsubscribe';
+	else
+		$mode = 'subscribe';
 
 	$topic_url = implode('/', array(
 		rtrim($settings['pmp_api_url'], '/'),

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -109,7 +109,7 @@ function pmp_post_subscription_data($mode, $topic_url) {
  */
 function pmp_store_verification_token($topic) {
 	$verify_token = hash('sha256', REQUEST_TIME);
-	set_transient('pmp_verify_token_' . hash('sha256', $topic), $verify_token, HOUR_IN_SECONDS);
+	set_transient(pmp_get_verify_key($topic), $verify_token, HOUR_IN_SECONDS);
 	return $verify_token;
 }
 
@@ -119,7 +119,16 @@ function pmp_store_verification_token($topic) {
  * @since 0.3
  */
 function pmp_get_verification_token($topic) {
-	return get_transient('pmp_verify_token_' . hash('sha256', $topic));
+	return get_transient(pmp_get_verify_key($topic));
+}
+
+/**
+ * Get the transient key for a topic (must be 40 characters or less)
+ *
+ * @since 0.3
+ */
+function pmp_get_verify_key($topic) {
+	return substr('pmp_verify_token_' . hash('sha256', $topic), 0, 40);
 }
 
 /**

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -195,6 +195,17 @@ function pmp_do_notification_callback() {
 			$item_json = json_decode(json_encode($item));
 			if ($idx = array_search($item_json->guid, $pmp_guids)) {
 				$post = get_post($pmp_post_data[$idx]->post_id);
+
+				// Honor the subscription setting for posts
+				$subscribed = get_post_meta(
+					$pmp_post_data[$idx]->post_id, 'pmp_subscribe_to_updates', true);
+
+				if (empty($subscribed))
+					$subscribed = 'on';
+
+				if ($subscribed !== 'on')
+					continue;
+
 				// TODO: Fetching the doc seems silly if the RSS item actually
 				// has all the appropriate data. However, the notifications docs
 				// don't detail what information is sent over the wire, so

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -44,6 +44,7 @@ add_action('template_redirect', 'pmp_notifications_template_redirect');
  * request to the PMP notifications server.
  *
  * @param $mode string either 'subscribe' or 'unsubscribe'
+ * @return boolean|string true on success, or a string error message
  * @since 0.3
  */
 function pmp_send_subscription_request($mode='subscribe') {
@@ -76,10 +77,18 @@ function pmp_send_subscription_request($mode='subscribe') {
 		)
 	));
 
-	if ($ret['response']['code'] == 204)
+	if ($ret['response']['code'] == 204) {
 		return true;
-	else
-		return false;
+	}
+	else if (!empty($ret['body'])) {
+		return $ret['body'];
+	}
+	else if (!empty($ret['response']['message'])) {
+		return $ret['response']['message'];
+	}
+	else {
+		return 'Unknown error - unable to update PMP notifications settings';
+	}
 }
 
 /**

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -141,7 +141,7 @@ function pmp_do_notification_callback() {
 		from $wpdb->postmeta where meta_key = 'pmp_guid'");
 	$pmp_guids = array_map(function($x) { return $x->pmp_guid; }, $pmp_post_data);
 
-	if ($headers['X-Hub-Signature'] == $hash) {
+	if ($headers['X-Hub-Signature'] == "sha1=$hash") {
 		$xml = simplexml_load_string($body);
 
 		foreach ($xml->channel->item as $item) {

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -1,0 +1,120 @@
+<?php
+
+// TODO: fix these
+define('PMP_NOTIFICATIONS_VERIFY_TOKEN', 'testverifytoken');
+define('PMP_NOTIFICATIONS_SECRET', 'testsecret');
+
+define('PMP_NOTIFICATIONS_HUB', 'notifications');
+define('PMP_NOTIFICATIONS_TOPIC', 'topics/updated');
+
+/**
+ * Add '?pmp-notifications' as a valid query var
+ *
+ * @since 0.3
+ */
+function pmp_bless_notification_query_var() {
+	add_rewrite_endpoint('pmp-notifications', EP_ALL);
+}
+add_action('init', 'pmp_bless_notification_query_var');
+
+/**
+ * Template redirect for PubSubHubBub operations
+ *
+ * If the request is POST, we're dealing with a notification.
+ *
+ * If the request is GET, we're being asked to verify a subscription.
+ *
+ * @since 0.3
+ */
+function pmp_notifications_template_redirect() {
+	global $wp_query;
+
+	if (!isset($wp_query->query_vars['pmp-notifications']))
+		return false;
+
+	if ($_SERVER['REQUEST_METHOD'] == 'POST')
+		pmp_do_notification_callback($_POST);
+
+	if ($_SERVER['REQUEST_METHOD'] == 'GET')
+		pmp_subscription_verification($_GET);
+
+	die();
+}
+add_action('template_redirect', 'pmp_notifications_template_redirect');
+
+/**
+ * When a user enables/disables PMP notifications service, send a subscription
+ * request to the PMP notifications server.
+ *
+ * @param $mode string either 'subscribe' or 'unsubscribe'
+ * @since 0.3
+ */
+function pmp_send_subscription_request($mode='subscribe', $hub=false) {
+	$settings = get_option('pmp_settings');
+
+	if (empty($hub))
+		$hub = rtrim($settings['pmp_api_url'], '/') . '/' . PMP_NOTIFICATIONS_HUB;
+
+	$sdk = new \Pmp\Sdk(
+		$settings['pmp_api_url'],
+		$settings['pmp_client_id'],
+		$settings['pmp_client_secret']
+	);
+
+	$ret = wp_remote_post($hub, array(
+		'method' => 'POST',
+		'headers' => array(
+			'Authorization' => 'Bearer ' . $sdk->home->getAccessToken()
+		),
+		'body' => array(
+			'hub.callback' => get_bloginfo('url') . '/?pmp-notifications',
+			'hub.mode' => $mode,
+			'hub.topic' => $hub . '/' . PMP_NOTIFICATIONS_TOPIC,
+			'hub.verify' => 'sync',
+			'hub.secret' => PMP_NOTIFICATIONS_SECRET,
+			'hub.verify_token' => PMP_NOTIFICATIONS_VERIFY_TOKEN
+		)
+	));
+
+	if ($ret['response']['code'] == 204)
+		return true;
+	else
+		return false;
+}
+
+/**
+ * Handle the PMP notification hub sending subscription verification to the callback
+ *
+ * @since 0.3
+ */
+function pmp_subscription_verification($data) {
+	if (isset($data['pmp-notifications']))
+		unset($data['pmp-notifications']);
+
+	$settings = get_option('pmp_settings');
+
+	if (isset($settings['pmp_use_api_notifications']) && $settings['pmp_use_api_notifications'] == 'off')
+		$mode = 'subscribe';
+	else
+		$mode = 'unsubscribe';
+
+	$topic_url = implode('/', array(
+		rtrim($settings['pmp_api_url'], '/'),
+		PMP_NOTIFICATIONS_HUB,
+		PMP_NOTIFICATIONS_TOPIC
+	));
+
+	if ($data['hub_verify_token'] == PMP_NOTIFICATIONS_VERIFY_TOKEN &&
+		$data['hub_topic'] == $topic_url &&
+		$data['hub_mode'] == $mode)
+	{
+		echo $data['hub_challenge'];
+	}
+}
+
+/**
+ * When the PMP notification hub sends an update, handle it
+ *
+ * @since 0.3
+ */
+function pmp_do_notification_callback() {}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -100,16 +100,20 @@ function pmp_settings_validate($input) {
 	}
 
 	if (!empty($input['pmp_use_api_notifications']) && !isset($options['pmp_use_api_notifications'])) {
-		$result = pmp_send_subscription_request('subscribe');
-		if ($result !== true) {
-			add_settings_error('pmp_settings_fields', 'pmp_notifications_subscribe_error', $result, 'error');
-			$errors = true;
+		foreach (pmp_get_topic_urls() as $topic_url) {
+			$result = pmp_send_subscription_request('subscribe', $topic_url);
+			if ($result !== true) {
+				add_settings_error('pmp_settings_fields', 'pmp_notifications_subscribe_error', $result, 'error');
+				$errors = true;
+			}
 		}
 	} else if (empty($input['pmp_use_api_notifications']) && isset($options['pmp_use_api_notifications'])) {
-		$result = pmp_send_subscription_request('unsubscribe');
-		if ($result !== true) {
-			add_settings_error('pmp_settings_fields', 'pmp_notifications_unsubscribe_error', $result, 'error');
-			$errors = true;
+		foreach (pmp_get_topic_urls() as $topic_url) {
+			$result = pmp_send_subscription_request('unsubscribe', $topic_url);
+			if ($result !== true) {
+				add_settings_error('pmp_settings_fields', 'pmp_notifications_unsubscribe_error', $result, 'error');
+				$errors = true;
+			}
 		}
 	}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -99,6 +99,16 @@ function pmp_settings_validate($input) {
 		$errors = true;
 	}
 
+	if (!empty($input['pmp_use_api_notifications'])) {
+		$result = pmp_send_subscription_request('subscribe');
+		if (!$result)
+			$errors = true;
+	} else {
+		$result = pmp_send_subscription_request('unsubscribe');
+		if (!$result)
+			$errors = true;
+	}
+
 	if (empty($errors))
 		pmp_update_my_guid_transient();
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -101,12 +101,16 @@ function pmp_settings_validate($input) {
 
 	if (!empty($input['pmp_use_api_notifications']) && !isset($options['pmp_use_api_notifications'])) {
 		$result = pmp_send_subscription_request('subscribe');
-		if (!$result)
+		if ($result !== true) {
+			add_settings_error('pmp_settings_fields', 'pmp_notifications_subscribe_error', $result, 'error');
 			$errors = true;
+		}
 	} else if (empty($input['pmp_use_api_notifications']) && isset($options['pmp_use_api_notifications'])) {
 		$result = pmp_send_subscription_request('unsubscribe');
-		if (!$result)
+		if ($result !== true) {
+			add_settings_error('pmp_settings_fields', 'pmp_notifications_unsubscribe_error', $result, 'error');
 			$errors = true;
+		}
 	}
 
 	if (empty($errors))

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -8,13 +8,36 @@
 function pmp_admin_init(){
 	register_setting('pmp_settings_fields', 'pmp_settings', 'pmp_settings_validate');
 
-	add_settings_section('pmp_main', null, null, 'pmp_settings');
+	add_settings_section('pmp_main', 'API Credentials', null, 'pmp_settings');
 
 	add_settings_field('pmp_api_url', 'API URL', 'pmp_api_url_input', 'pmp_settings', 'pmp_main');
 	add_settings_field('pmp_client_id', 'Client ID', 'pmp_client_id_input', 'pmp_settings', 'pmp_main');
 	add_settings_field('pmp_client_secret', 'Client Secret', 'pmp_client_secret_input', 'pmp_settings', 'pmp_main');
+
+	add_settings_section('pmp_cron', 'Misc. options', null, 'pmp_settings');
+
+	add_settings_field(
+		'pmp_use_api_notifications', 'Allow PMP API to send content updates?',
+		'pmp_use_api_notifications_input', 'pmp_settings', 'pmp_cron');
 }
 add_action('admin_init', 'pmp_admin_init');
+
+/**
+ * Input field for PMP API notifications on/off
+ *
+ * @since 0.3
+ */
+function pmp_use_api_notifications_input() {
+	$options = get_option('pmp_settings');
+	$setting = (isset($options['pmp_use_api_notifications']))? $options['pmp_use_api_notifications'] : false;
+	?>
+		<input id="pmp_use_api_notifications" type="checkbox"
+			name="pmp_settings[pmp_use_api_notifications]"
+			<?php echo checked($setting, 'on'); ?>>Enable</input>
+	<p><em>Enabling this option allows the PMP API to push to your site as new story, audio, image, etc. updates become available.<em></p>
+	<p><em>This may help improve performance of your site, especially if you have a large number of imported posts.</em></p>
+<?php
+}
 
 /**
  * Input field for PMP API URL

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -99,11 +99,11 @@ function pmp_settings_validate($input) {
 		$errors = true;
 	}
 
-	if (!empty($input['pmp_use_api_notifications'])) {
+	if (!empty($input['pmp_use_api_notifications']) && !isset($options['pmp_use_api_notifications'])) {
 		$result = pmp_send_subscription_request('subscribe');
 		if (!$result)
 			$errors = true;
-	} else {
+	} else if (empty($input['pmp_use_api_notifications']) && isset($options['pmp_use_api_notifications'])) {
 		$result = pmp_send_subscription_request('unsubscribe');
 		if (!$result)
 			$errors = true;

--- a/plugin.php
+++ b/plugin.php
@@ -152,7 +152,10 @@ register_activation_hook(__FILE__, 'pmp_setup_cron_on_activation');
  * @since 0.1
  */
 function pmp_hourly_cron() {
-	pmp_get_updates();
+	$options = get_option('pmp_settings');
+	if (!isset($options['pmp_use_api_notifications']) || $options['pmp_use_api_notifications'] !== 'on')
+		pmp_get_updates();
+
 	pmp_import_for_saved_queries();
 }
 add_action('pmp_hourly_cron', 'pmp_hourly_cron');

--- a/plugin.php
+++ b/plugin.php
@@ -35,7 +35,8 @@ function pmp_init() {
 		'inc/assets.php',
 		'inc/ajax.php',
 		'inc/cron.php',
-		'inc/meta-boxes.php'
+		'inc/meta-boxes.php',
+		'inc/notifications.php'
 	);
 
 	foreach ($includes as $include)

--- a/tests/inc/test-notifications.php
+++ b/tests/inc/test-notifications.php
@@ -1,0 +1,41 @@
+<?php
+
+class TestNotifications extends WP_UnitTestCase {
+
+	function test_pmp_bless_notification_query_var() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_notifications_template_redirect() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_send_subscription_request() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_post_subscription_data() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_store_verification_token() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_get_verification_token() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_subscription_verification() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_get_topic_urls() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+	function test_pmp_do_notification_callback() {
+		$this->markTestIncomplete('This test has not been implemented yet.');
+	}
+
+}

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -8,37 +8,57 @@ class TestSettings extends WP_UnitTestCase {
 		$this->assertTrue(isset($new_whitelist_options['pmp_settings_fields']));
 
 		global $wp_settings_sections;
-		$section = array(
-			'id' => 'pmp_main',
-			'title' => null,
-			'callback' => null
+		$sections = array(
+			'pmp_main' => array(
+				'id' => 'pmp_main',
+				'title' => 'API Credentials',
+				'callback' => null
+			),
+			'pmp_cron' => array(
+				'id' => 'pmp_cron',
+				'title' => 'Misc. options',
+				'callback' => null
+			)
 		);
-		$this->assertTrue($wp_settings_sections['pmp_settings']['pmp_main'] == $section);
+		$this->assertTrue($wp_settings_sections['pmp_settings'] == $sections);
 
 		global $wp_settings_fields;
 		$fields = array(
-			array(
-				'id' => 'pmp_api_url',
-				'title' => 'API URL',
-				'callback' => 'pmp_api_url_input',
-				'args' => null
+			'pmp_main' => array(
+				array(
+					'id' => 'pmp_api_url',
+					'title' => 'API URL',
+					'callback' => 'pmp_api_url_input',
+					'args' => null
+				),
+				array(
+					'id' => 'pmp_client_id',
+					'title' => 'Client ID',
+					'callback' => 'pmp_client_id_input',
+					'args' => null
+				),
+				array(
+					'id' => 'pmp_client_secret',
+					'title' => 'Client Secret',
+					'callback' => 'pmp_client_secret_input',
+					'args' => null
+				)
 			),
-			array(
-				'id' => 'pmp_client_id',
-				'title' => 'Client ID',
-				'callback' => 'pmp_client_id_input',
-				'args' => null
-			),
-			array(
-				'id' => 'pmp_client_secret',
-				'title' => 'Client Secret',
-				'callback' => 'pmp_client_secret_input',
-				'args' => null
+			'pmp_cron' => array(
+				array(
+					'id' => 'pmp_use_api_notifications',
+					'title' => 'Allow PMP API to send content updates?',
+					'callback' => 'pmp_use_api_notifications_input',
+					'args' => null
+				)
 			)
 		);
 
-		foreach ($fields as $field) {
-			$this->assertTrue($wp_settings_fields['pmp_settings']['pmp_main'][$field['id']] == $field);
+		foreach (array_keys($sections) as $section_id) {
+			$section_fields = $fields[$section_id];
+			foreach ($section_fields as $field) {
+				$this->assertTrue($wp_settings_fields['pmp_settings'][$section_id][$field['id']] == $field);
+			}
 		}
 	}
 


### PR DESCRIPTION
NOTE: this is a work in progress and needs testing.

This pull request:

- Adds an "Allow PMP API to send content updates?" option to the settings panel:

![image](https://cloud.githubusercontent.com/assets/72608/8940399/551067ec-352f-11e5-9926-04226d7d1ebc.png)

- When saving settings, if the "Enable" option is checked, the PMP plugin runs the subscription and verification workflow.
- When savings settings, if the "Enable" option is unchecked, the PMP plugin runs the unsubscribe process.
- When this option is enabled, the PMP plugin does not poll for updates to content via cron.
- Also blesses "/?pmp-notifications" as a valid query parameter and uses said query parameter in the callback url used for communicating with the PMP hub.

Still needs:

- Documentation
- Probably would be a good idea to link to the PMP docs for the notification system
- Unit tests
- ???