### PR TITLE
Refactor pmp sync

### DIFF
--- a/inc/ajax.php
+++ b/inc/ajax.php
@@ -365,7 +365,7 @@ function _pmp_create_post($draft=false, $doc=null) {
 			var_log('pmp_media_sideload_image ERROR: ' . $new_attachment->get_error_message());
 		}
 		else if (!$have_set_featured) {
-			update_post_meta($post_id, '_thumbnail_id', $new_attachment);
+			update_post_meta($new_post, '_thumbnail_id', $new_attachment);
 			$have_set_featured = true;
 		}
 	}

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -32,28 +32,6 @@ function pmp_get_pmp_posts() {
 }
 
 /**
- * Query for Post-attachments originating from PMP media
- *
- * @since 0.3
- */
-function pmp_get_pmp_attachments($parent_id) {
-	if (!$parent_id || $parent_id < 1) return array();
-
-	$query = new WP_Query(array(
-		'meta_query' => array(
-			'key' => 'pmp_guid',
-			'compare' => 'EXISTS'
-		),
-		'posts_per_page' => -1,
-		'post_type' => 'attachment',
-		'post_status' => 'any',
-		'post_parent' => $parent_id,
-	));
-
-	return $query->posts;
-}
-
-/**
  * For each PMP post in the WP database, fetch the corresponding Doc from PMP and check if
  * the WP post differs from the PMP Doc. If it does differ, update the post in the WP database.
  *
@@ -81,6 +59,8 @@ function pmp_get_updates() {
 					if (pmp_needs_update($post, $doc))
 						pmp_update_post($post, $doc);
 				} else {
+					pmp_debug("-- deleting wp_post[{$wp_post->ID}] pmp[{$pmp_doc->attributes->guid}]");
+					pmp_delete_post_attachments($post->ID);
 					wp_delete_post($post->ID, true);
 				}
 			}

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -55,13 +55,13 @@ function pmp_get_updates() {
 			$guid = $custom_fields['pmp_guid'][0];
 			if (!empty($guid)) {
 				$doc = $sdk->fetchDoc($guid);
-				if (!empty($doc)) {
-					if (pmp_needs_update($post, $doc))
-						pmp_update_post($post, $doc);
-				} else {
-					pmp_debug("-- deleting wp_post[{$wp_post->ID}] pmp[{$pmp_doc->attributes->guid}]");
+				if (empty($doc)) {
+					pmp_debug("-- deleting wp[{$wp_post->ID}] pmp[{$pmp_doc->attributes->guid}]");
 					pmp_delete_post_attachments($post->ID);
 					wp_delete_post($post->ID, true);
+				}
+				else if (pmp_needs_update($post, $doc)) {
+					pmp_update_post($post, $doc);
 				}
 			}
 		}
@@ -75,7 +75,7 @@ function pmp_get_updates() {
  * @since 0.1
  */
 function pmp_needs_update($wp_post, $pmp_doc) {
-	$log_ident = "wp_post[{$wp_post->ID}] pmp[{$pmp_doc->attributes->guid}]";
+	$log_ident = "wp[{$wp_post->ID}] pmp[{$pmp_doc->attributes->guid}]";
 
 	// pull metadata (and turn meta-arrays into single values)
 	$pmp_modified = get_post_meta($wp_post->ID, 'pmp_modified', true);

--- a/inc/cron.php
+++ b/inc/cron.php
@@ -56,8 +56,7 @@ function pmp_get_updates() {
 			if (!empty($guid)) {
 				$doc = $sdk->fetchDoc($guid);
 				if (empty($doc)) {
-					pmp_debug("-- deleting wp[{$wp_post->ID}] pmp[{$pmp_doc->attributes->guid}]");
-					pmp_delete_post_attachments($post->ID);
+					pmp_debug("-- deleting wp[{$post->ID}] pmp[$guid]");
 					wp_delete_post($post->ID, true);
 				}
 				else if (pmp_needs_update($post, $doc)) {

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -603,3 +603,17 @@ if (!function_exists('var_log')) {
 	 */
 	function var_log($stuff) { error_log(var_export($stuff, true)); }
 }
+
+/**
+ * Debug logger
+ *
+ * @param mixed $stuff the data structure to send to the error log.
+ * @since 0.3
+ */
+function pmp_debug($stuff) {
+	if (PMP_DEBUG) {
+		$str = var_export($stuff, true);
+		$time = date('Y-m-d\TH:m:s');
+		error_log("DEBUG [$time] $str");
+	}
+}

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -88,6 +88,40 @@ function pmp_media_sideload_image($file, $post_id, $desc=null) {
 }
 
 /**
+ * Query for Post-attachments originating from PMP media
+ *
+ * @since 0.3
+ */
+function pmp_get_pmp_attachments($parent_id) {
+	if (!$parent_id || $parent_id < 1) return array();
+
+	$query = new WP_Query(array(
+		'meta_query' => array(
+			'key' => 'pmp_guid',
+			'compare' => 'EXISTS'
+		),
+		'posts_per_page' => -1,
+		'post_type' => 'attachment',
+		'post_status' => 'any',
+		'post_parent' => $parent_id,
+	));
+
+	return $query->posts;
+}
+
+/**
+ * Delete any attachments to a PMP-sourced Post
+ *
+ * @since 0.3
+ */
+function pmp_delete_post_attachments($post_id) {
+	$attachments = pmp_get_pmp_attachments($post_id);
+	foreach ($attachments as $attach) {
+		wp_delete_post($attach->ID, true);
+	}
+}
+
+/**
  * Verify that we have all settings required to successfully query the PMP API.
  *
  * @since 0.1

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -297,11 +297,17 @@ function pmp_handle_push($post_id) {
 
 		$series = pmp_get_collection_override_value($post_id, 'series');
 		if (!empty($series))
-			$obj->links->collection[] = (object) array('href' => $sdk->href4guid($series));
+			$obj->links->collection[] = (object) array(
+				'href' => $sdk->href4guid($series),
+				'rels' => array('urn:collectiondoc:collection:series'),
+			);
 
 		$property = pmp_get_collection_override_value($post_id, 'property');
 		if (!empty($property))
-			$obj->links->collection[] = (object) array('href' => $sdk->href4guid($property));
+			$obj->links->collection[] = (object) array(
+				'href' => $sdk->href4guid($property),
+				'rels' => array('urn:collectiondoc:collection:property'),
+			);
 	}
 
 	// Build out the permissions group profile array
@@ -318,7 +324,10 @@ function pmp_handle_push($post_id) {
 		$obj->links->item = array();
 
 		if (!empty($featured_img_guid))
-			$obj->links->item[] = (object) array('href' => $sdk->href4guid($featured_img_guid));
+			$obj->links->item[] = (object) array(
+				'href' => $sdk->href4guid($featured_img_guid),
+				'rels' => array('urn:collectiondoc:image', 'urn:collectiondoc:image:featured'),
+			);
 	}
 
 	// If this is an attachment post, build out the enclosures array to be sent over the wire.

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -57,6 +57,7 @@ function pmp_get_profiles() {
  */
 function pmp_media_sideload_image($file, $post_id, $desc=null) {
 	if (!empty($file)) {
+		pmp_debug("  -- sideloading-image $file for post[$post_id]");
 		include_once ABSPATH . 'wp-admin/includes/image.php';
 		include_once ABSPATH . 'wp-admin/includes/file.php';
 		include_once ABSPATH . 'wp-admin/includes/media.php';

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -223,8 +223,10 @@ function pmp_do_notification_callback() {
 				if (!empty($doc)) {
 					if (pmp_needs_update($post, $doc))
 						pmp_update_post($post, $doc);
-				} else
+				} else {
+					pmp_delete_post_attachments($post->ID);
 					wp_delete_post($post->ID, true);
+				}
 			}
 		}
 	}

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -252,7 +252,6 @@ function pmp_do_notification_callback() {
 			$doc = $sdk->fetchDoc($item_guid);
 			if (empty($doc)) {
 				pmp_debug("-- deleting wp[{$post->ID}] pmp[{$item_guid}]");
-				pmp_delete_post_attachments($post->ID);
 				wp_delete_post($post->ID, true);
 			}
 			else if (pmp_needs_update($post, $doc)) {

--- a/inc/notifications.php
+++ b/inc/notifications.php
@@ -188,45 +188,75 @@ function pmp_get_topic_urls() {
 function pmp_do_notification_callback() {
 	global $wpdb;
 
+	pmp_debug('========== pmp_do_notification_callback ==========');
+
 	$sdk = new SDKWrapper();
 	$body = file_get_contents('php://input');
 	$hash = hash_hmac('sha1', $body, PMP_NOTIFICATIONS_SECRET);
 
-	$pmp_post_data = $wpdb->get_results("
-		select meta_value as pmp_guid, post_id
-		from $wpdb->postmeta where meta_key = 'pmp_guid'");
-	$pmp_guids = array_map(function($x) { return $x->pmp_guid; }, $pmp_post_data);
+	// get a COMPLETE mapping of known-PMP-guids to top-level WP-posts
+	$pmp_post_data = $wpdb->get_results(
+		'SELECT pm.meta_key, pm.meta_value, pm.post_id, p.post_parent ' .
+		'FROM wp_postmeta pm JOIN wp_posts p ON (pm.post_id = p.id) ' .
+		'WHERE meta_key = "pmp_guid" OR meta_key = "pmp_audio"'
+	);
 
-	if ($_SERVER['HTTP_X_HUB_SIGNATURE'] == "sha1=$hash") {
-		$xml = simplexml_load_string($body);
-
-		foreach ($xml->channel->item as $item) {
-			$item_json = json_decode(json_encode($item));
-			if ($idx = array_search($item_json->guid, $pmp_guids)) {
-				$post = get_post($pmp_post_data[$idx]->post_id);
-
-				// Honor the subscription setting for posts
-				$subscribed = get_post_meta(
-					$pmp_post_data[$idx]->post_id, 'pmp_subscribe_to_updates', true);
-
-				if (empty($subscribed))
-					$subscribed = 'on';
-
-				if ($subscribed !== 'on')
-					continue;
-
-				// TODO: Fetching the doc seems silly if the RSS item actually
-				// has all the appropriate data. However, the notifications docs
-				// don't detail what information is sent over the wire, so
-				// we can't make that assumption.
-				$doc = $sdk->fetchDoc($pmp_post_data[$idx]->pmp_guid);
-				if (!empty($doc)) {
-					if (pmp_needs_update($post, $doc))
-						pmp_update_post($post, $doc);
-				} else {
-					pmp_delete_post_attachments($post->ID);
-					wp_delete_post($post->ID, true);
+	// map to the TOP LEVEL post (including the pmp_audio arrays)
+	$pmp_guids = array();
+	foreach ($pmp_post_data as $data) {
+		if ($data->meta_key === 'pmp_guid' && $data->post_parent > 0) {
+			if ($data->post_parent > 0) {
+				$pmp_guids[$data->meta_value] = $data->post_parent;
+			}
+			else {
+				$pmp_guids[$data->meta_value] = $data->post_id;
+			}
+		}
+		else {
+			$audios = unserialize($data->meta_value);
+			if ($audios && is_array($audios)) {
+				foreach ($audios as $guid => $modified) {
+					$pmp_guids[$guid] = $data->post_id;
 				}
+			}
+		}
+	}
+
+	// check hub signature
+	if ($_SERVER['HTTP_X_HUB_SIGNATURE'] !== "sha1=$hash") {
+		var_log('INVALID PMP notifications HTTP_X_HUB_SIGNATURE');
+		var_log("  Expected: sha1=$hash");
+		var_log("  Got:      " . $_SERVER['HTTP_X_HUB_SIGNATURE']);
+		return;
+	}
+
+	// parse xml pubsubhubbub body
+	$xml = simplexml_load_string($body);
+	foreach ($xml->channel->item as $item) {
+		$item_json = json_decode(json_encode($item));
+		$item_guid = $item_json->guid;
+
+		// look for Posts tied to that guid
+		if (isset($pmp_guids[$item_guid])) {
+			$post = get_post($pmp_guids[$item_guid]);
+
+			// Honor the subscription setting for posts
+			$subscribed = get_post_meta($post->ID, 'pmp_subscribe_to_updates', true);
+			$subscribed = empty($subscribed) ? 'on' : $subscribed;
+			if ($subscribed !== 'on') {
+				pmp_debug("-- skipping wp[{$post->ID}] pmp[{$item_guid}] due to 'off' setting");
+				continue;
+			}
+
+			// Fetch document from PMP and sync changes
+			$doc = $sdk->fetchDoc($item_guid);
+			if (empty($doc)) {
+				pmp_debug("-- deleting wp[{$post->ID}] pmp[{$item_guid}]");
+				pmp_delete_post_attachments($post->ID);
+				wp_delete_post($post->ID, true);
+			}
+			else if (pmp_needs_update($post, $doc)) {
+				pmp_update_post($post, $doc);
 			}
 		}
 	}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -10,7 +10,8 @@ function pmp_admin_init(){
 
 	add_settings_section('pmp_main', 'API Credentials', null, 'pmp_settings');
 
-	add_settings_field('pmp_api_url', 'API URL', 'pmp_api_url_input', 'pmp_settings', 'pmp_main');
+	add_settings_field('pmp_user_title', 'Connected As', 'pmp_user_title_input', 'pmp_settings', 'pmp_main');
+	add_settings_field('pmp_api_url', 'PMP Environment', 'pmp_api_url_input', 'pmp_settings', 'pmp_main');
 	add_settings_field('pmp_client_id', 'Client ID', 'pmp_client_id_input', 'pmp_settings', 'pmp_main');
 	add_settings_field('pmp_client_secret', 'Client Secret', 'pmp_client_secret_input', 'pmp_settings', 'pmp_main');
 
@@ -46,8 +47,13 @@ function pmp_use_api_notifications_input() {
  */
 function pmp_api_url_input() {
 	$options = get_option('pmp_settings');
+	$is_production = empty($options['pmp_api_url']) || $options['pmp_api_url'] === 'https://api.pmp.io';
+	$is_sandbox = !$is_production;
 	?>
-		<input id="pmp_api_url" name="pmp_settings[pmp_api_url]" type="text" value="<?php echo $options['pmp_api_url']; ?>" />
+		<select id="pmp_api_url" name="pmp_settings[pmp_api_url]">
+		  <option <?php echo $is_production ? 'selected' : '' ?> value="https://api.pmp.io">Production</option>
+		  <option <?php echo $is_sandbox ? 'selected' : '' ?> value="https://api-sandbox.pmp.io">Sandbox</option>
+		</select>
 	<?php
 }
 
@@ -76,6 +82,32 @@ function pmp_client_secret_input() {
 	<?php } else { ?>
 		<a href="#" id="pmp_client_secret_reset">Change client secret</a>
 	<?php }
+}
+/**
+ * Static field for currently connected user
+ *
+ * @since 0.3
+ */
+function pmp_user_title_input() {
+	$options = get_option('pmp_settings');
+	if (empty($options['pmp_api_url']) || empty($options['pmp_client_id'] || empty($options['pmp_client_secret']))) {
+		echo '<p><em>Not connected</em></p>';
+	}
+	else {
+		try {
+			$sdk = new SDKWrapper();
+			$me = $sdk->fetchUser('me');
+			$title = $me->attributes->title;
+			$link = pmp_get_support_link($me->attributes->guid);
+			echo "<p><a target='_blank' href='$link'>$title</a></p>";
+		}
+		catch (\Pmp\Sdk\Exception\AuthException $e) {
+			echo '<p style="color:#a94442"><b>Unable to connect - invalid Client-Id/Secret</b></p>';
+		}
+		catch (\Pmp\Sdk\Exception\HostException $e) {
+			echo '<p style="color:#a94442"><b>Unable to connect - ' . $options['pmp_api_url'] . ' is unreachable</b></p>';
+		}
+	}
 }
 
 /**

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -90,7 +90,7 @@ function pmp_client_secret_input() {
  */
 function pmp_user_title_input() {
 	$options = get_option('pmp_settings');
-	if (empty($options['pmp_api_url']) || empty($options['pmp_client_id'] || empty($options['pmp_client_secret']))) {
+	if (empty($options['pmp_api_url']) || empty($options['pmp_client_id']) || empty($options['pmp_client_secret'])) {
 		echo '<p><em>Not connected</em></p>';
 	}
 	else {

--- a/plugin.php
+++ b/plugin.php
@@ -27,6 +27,7 @@ function pmp_init() {
 	define('PMP_PLUGIN_DIR_URI', plugins_url(basename(__DIR__), __DIR__));
 	define('PMP_TEMPLATE_DIR', PMP_PLUGIN_DIR . '/templates');
 	define('PMP_VERSION', 0.1);
+	define('PMP_DEBUG', true);
 
 	$includes = array(
 		'inc/functions.php',

--- a/plugin.php
+++ b/plugin.php
@@ -27,7 +27,9 @@ function pmp_init() {
 	define('PMP_PLUGIN_DIR_URI', plugins_url(basename(__DIR__), __DIR__));
 	define('PMP_TEMPLATE_DIR', PMP_PLUGIN_DIR . '/templates');
 	define('PMP_VERSION', 0.1);
-	define('PMP_DEBUG', true);
+
+	if (!defined('PMP_DEBUG'))
+		define('PMP_DEBUG', WP_DEBUG);
 
 	$includes = array(
 		'inc/functions.php',

--- a/tests/inc/test-functions.php
+++ b/tests/inc/test-functions.php
@@ -224,9 +224,12 @@ class TestFunctions extends WP_UnitTestCase {
 		$this->assertEquals($post_meta['pmp_guid'], $this->pmp_story['attributes']['guid']);
 		$this->assertEquals($post_meta['pmp_created'], $this->pmp_story['attributes']['created']);
 		$this->assertEquals($post_meta['pmp_modified'], $this->pmp_story['attributes']['modified']);
-		$this->assertEquals($post_meta['pmp_byline'], $this->pmp_story['attributes']['byline']);
 		$this->assertEquals($post_meta['pmp_published'], $this->pmp_story['attributes']['published']);
 		$this->assertEquals($post_meta['pmp_owner'], SDKWrapper::guid4href($this->pmp_story['links']['owner'][0]->href));
+
+		// The byline is not guaranteed to be present
+		if (!empty($this->pmp_story['attributes']['byline']))
+			$this->assertEquals($post_meta['pmp_byline'], $this->pmp_story['attributes']['byline']);
 	}
 
 	function test_pmp_filter_media_library() {

--- a/tests/inc/test-settings.php
+++ b/tests/inc/test-settings.php
@@ -26,8 +26,14 @@ class TestSettings extends WP_UnitTestCase {
 		$fields = array(
 			'pmp_main' => array(
 				array(
+					'id' => 'pmp_user_title',
+					'title' => 'Connected As',
+					'callback' => 'pmp_user_title_input',
+					'args' => null
+				),
+				array(
 					'id' => 'pmp_api_url',
-					'title' => 'API URL',
+					'title' => 'PMP Environment',
 					'callback' => 'pmp_api_url_input',
 					'args' => null
 				),
@@ -63,7 +69,7 @@ class TestSettings extends WP_UnitTestCase {
 	}
 
 	function test_pmp_api_url_input() {
-		$expect = '/<input id="pmp_api_url" name="pmp_settings\[pmp_api_url\]" type="text"/';
+		$expect = '/<select id="pmp_api_url" name="pmp_settings\[pmp_api_url\]"/';
 		$this->expectOutputRegex($expect);
 		pmp_api_url_input();
 	}


### PR DESCRIPTION
Refactoring pieces of the "PMP sync-post" process to address some long underlying issues.

1. More debug statements (tied to a `PMP_DEBUG` constant)
2. Ensure updating a Post is exactly the same as creating from scratch
3. Better differentiate between Posts and Attachments (and cleanup Attachments when the PMP-Post goes away)
4. Check for audio/image changes, both in the cron-updates and push-notifications.  Trigger a refresh of the parent Post (probably a Story) when the child items change.