### PR TITLE
Try replacing foo.bar with example.org

### DIFF
--- a/tests/inc/test-class-pmpsyncer-pull.php
+++ b/tests/inc/test-class-pmpsyncer-pull.php
@@ -186,7 +186,7 @@ class TestPmpSyncerPull extends PMP_SyncerTestCase {
     $this->assertEquals($syncer->attachment_syncers[0]->post->ID, get_post_meta($syncer->post->ID, '_thumbnail_id', true));
 
     // invalid enclosures hrefs just end up deleting the image altogether
-    $syncer->attachment_syncers[0]->doc->links->enclosure[0]->href = 'http://foo.bar';
+    $syncer->attachment_syncers[0]->doc->links->enclosure[0]->href = 'http://example.org';
     $this->assertTrue($syncer->pull(true));
     $this->assertFalse($syncer->attachment_syncers[0]->pull(true));
     $this->assertNull($syncer->attachment_syncers[0]->post);


### PR DESCRIPTION
This is because of an error in tests for merging `allow-multiple-groups` into `master`: https://travis-ci.org/publicmediaplatform/pmp-wordpress/jobs/148451149

```
insert_post ERROR for attachment [6df12b26-9435-4009-8bfb-2c5ad7b08d34] - Couldn't resolve host 'foo.bar'
insert_post ERROR for attachment [6df12b26-9435-4009-8bfb-2c5ad7b08d34] - Couldn't resolve host 'foo.bar'
```

The goal of this PR is:

1. Trigger tests
2. Don't get the `Couldn't resolve host 'foo.bar'` error